### PR TITLE
Replaced `WhisperX` Support with `faster-whisper` for Greater Flexibility

### DIFF
--- a/.github/workflows/manuel_publish.yml
+++ b/.github/workflows/manuel_publish.yml
@@ -26,4 +26,4 @@ jobs:
         with:
           pypi_token: ${{ secrets.PYPI_API_TOKEN }}
           plugins: "poetry-dynamic-versioning"
-          repository_name: "scraibe-webui"
+          repository_name: "scraibe"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ python = "^3.9"
 tqdm = "^4.66.4"
 numpy = "^1.26.4"
 openai-whisper = "^20231117"
-whisperx = "^3.1.3"
+faster-whisper = "^1.0.1"
 "pyannote.audio" = "^3.1.1"
 torch = "^2.3.0"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ tqdm>=4.65.0
 numpy>=1.26.4
 
 openai-whisper==20231117
-whisperx~=3.1.3
+faster-whisper~=1.0.1
 
 pyannote.audio~=3.1.1
 pyannote.core~=5.0.0

--- a/scraibe/autotranscript.py
+++ b/scraibe/autotranscript.py
@@ -74,7 +74,7 @@ class Scraibe:
             whisper_model (Union[bool, str, whisper], optional): 
                                 Path to whisper model or whisper model itself.
             whisper_type (str):
-                                Type of whisper model to load. "whisper" or "whisperx".
+                                Type of whisper model to load. "whisper" or "faster-whisper".
             diarisation_model (Union[bool, str, DiarisationType], optional): 
                                 Path to pyannote diarization model or model itself.
             **kwargs: Additional keyword arguments for whisper

--- a/scraibe/cli.py
+++ b/scraibe/cli.py
@@ -36,8 +36,8 @@ def cli():
                         help="List of audio files to transcribe.")
 
     parser.add_argument("--whisper-type", type=str, default="whisper",
-                        choices=["whisper", "whisperx"],
-                        help="Type of Whisper model to use ('whisper' or 'whisperx').")
+                        choices=["whisper", "faster-whisper"],
+                        help="Type of Whisper model to use ('whisper' or 'faster-whisper').")
     
     parser.add_argument("--whisper-model-name", default="medium",
                         help="Name of the Whisper model to use.")

--- a/scraibe/misc.py
+++ b/scraibe/misc.py
@@ -16,7 +16,7 @@ WHISPER_DEFAULT_PATH = os.path.join(CACHE_DIR, "whisper")
 PYANNOTE_DEFAULT_PATH = os.path.join(CACHE_DIR, "pyannote")
 PYANNOTE_DEFAULT_CONFIG = os.path.join(PYANNOTE_DEFAULT_PATH, "config.yaml") \
     if os.path.exists(os.path.join(PYANNOTE_DEFAULT_PATH, "config.yaml")) \
-    else ('jaikinator/scraibe', 'pyannote/speaker-diarization-3.1')
+    else ('Jaikinator/ScrAIbe', 'pyannote/speaker-diarization-3.1')
 
 
 def config_diarization_yaml(file_path: str, path_to_segmentation: str = None) -> None:

--- a/test/test_transcriber.py
+++ b/test/test_transcriber.py
@@ -1,6 +1,6 @@
 import pytest
 from scraibe import (Transcriber, WhisperTranscriber,
-                     WhisperXTranscriber, load_transcriber)
+                     FasterWhisperTranscriber, load_transcriber)
 import torch
 
 
@@ -35,24 +35,24 @@ def whisper_instance():
 
 
 @pytest.fixture
-def whisperx_instance():
-    return load_transcriber('medium', whisper_type='whisperx')
+def faster_whisper_instance():
+    return load_transcriber('medium', whisper_type='faster-whisper')
 
 
 def test_whisper_base_initialization(whisper_instance):
     assert isinstance(whisper_instance, Transcriber)
 
 
-def test_whisperx_base_initialization(whisperx_instance):
-    assert isinstance(whisperx_instance, Transcriber)
+def test_faster_whisper_base_initialization(faster_whisper_instance):
+    assert isinstance(faster_whisper_instance, Transcriber)
 
 
 def test_whisper_transcriber_initialization(whisper_instance):
     assert isinstance(whisper_instance, WhisperTranscriber)
 
 
-def test_whisperx_transcriber_initialization(whisperx_instance):
-    assert isinstance(whisperx_instance, WhisperXTranscriber)
+def test_faster_whisper_transcriber_initialization(faster_whisper_instance):
+    assert isinstance(faster_whisper_instance, FasterWhisperTranscriber)
 
 
 def test_wrong_transcriber_initialization():
@@ -73,8 +73,8 @@ def test_whisper_transcribe(whisper_instance):
     assert isinstance(transcript, str)
 
 
-def test_whisperx_transcribe(whisperx_instance):
-    model = whisperx_instance
+def test_faster_whisper_transcribe(faster_whisper_instance):
+    model = faster_whisper_instance
     # mocker.patch.object(transcriber_instance.model, 'transcribe', return_value={'Hello, World !'} )
     transcript = model.transcribe('test/audio_test_2.mp4')
     assert isinstance(transcript, str)

--- a/tests/test_diarization.py
+++ b/tests/test_diarization.py
@@ -1,0 +1,10 @@
+from os import environ
+
+environ["AUTOT_CACHE"] = "/mnt/disk1/Projekte/ScrAIbe/tests"
+# environ["PYANNOTE_CACHE"] = "/mnt/disk1/Projekte/ScrAIbe/tests/pyannote"
+# environ["TORCH_HOME"] = "/mnt/disk1/Projekte/ScrAIbe/tests/torch"
+
+from scraibe import Scraibe
+
+scraibe = Scraibe(whisper_type = "faster-whisper", whisper_model = "tiny")
+print(scraibe.autotranscribe('/mnt/disk1/Projekte/ScrAIbe/test/audio_test_1.mp4'))


### PR DESCRIPTION
- Removed support for [WhisperX](https://github.com/m-bain/whisperX) and replaced it with [faster-whisper](https://github.com/SYSTRAN/faster-whisper).
- Since `WhisperX` is built on top of `faster-whisper`, we have decided to use the underlying `faster-whisper` package directly.
- This change provides more flexibility and simplifies the integration, giving us better control over the functionality while maintaining all necessary features.